### PR TITLE
Replace 'inout' with 'mut' for forwards compatibility with Mojo

### DIFF
--- a/flexbuffers/cache.mojo
+++ b/flexbuffers/cache.mojo
@@ -10,7 +10,7 @@ struct Key(CollectionElement):
     var pointer: BufPointer
     var size: Int
 
-    fn __init__(inout self, pointer: BufPointer, size: Int):
+    fn __init__(mut self, pointer: BufPointer, size: Int):
         var cp = BufPointer.alloc(size)
         memcpy(cp, pointer, size)
         self.pointer = cp
@@ -29,7 +29,7 @@ struct _CacheStackValue(Movable, Copyable):
     var count: Int
     var capacity: Int
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self.count = 0
         self.capacity = 16
         self.keys = Keys(capacity=self.capacity)
@@ -37,14 +37,14 @@ struct _CacheStackValue(Movable, Copyable):
         self.key_map = KeyMapPointer.alloc(self.capacity)
         memset_zero(self.key_map, self.capacity)
 
-    fn __moveinit__(inout self, owned other: Self):
+    fn __moveinit__(mut self, owned other: Self):
         self.count = other.count
         self.capacity = other.capacity
         self.values = other.values^
         self.key_map = other.key_map
         self.keys = other.keys^
 
-    fn __copyinit__(inout self, other: Self):
+    fn __copyinit__(mut self, other: Self):
         self.count = other.count
         self.capacity = other.capacity
         var keys_count = len(other.keys)
@@ -71,12 +71,12 @@ struct _CacheStackValue(Movable, Copyable):
             var key = self.keys[i]
             key.pointer.free()
 
-    fn put(inout self, key: Key, value: StackValue):
+    fn put(mut self, key: Key, value: StackValue):
         if self.count / self.capacity >= 0.8:
             self._rehash()
         self._put(key, value, -1)
 
-    fn _rehash(inout self):
+    fn _rehash(mut self):
         # var old_mask_capacity = self.capacity >> 3
         self.key_map.free()
         self.capacity <<= 1
@@ -87,7 +87,7 @@ struct _CacheStackValue(Movable, Copyable):
         for i in range(len(self.keys)):
             self._put(self.keys[i], self.values[i], i + 1)
 
-    fn _put(inout self, key: Key, value: StackValue, rehash_index: Int):
+    fn _put(mut self, key: Key, value: StackValue, rehash_index: Int):
         var key_hash = self._hash(key)
         var modulo_mask = self.capacity - 1
         var key_map_index = int(key_hash & modulo_mask)
@@ -217,20 +217,20 @@ struct _CacheStringOrKey(Movable, Copyable):
     var count: Int
     var capacity: Int
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self.count = 0
         self.capacity = 16
         self.ocs = List[OffsetAndCount](capacity=self.capacity)
         self.key_map = KeyMapPointer.alloc(self.capacity)
         memset_zero(self.key_map, self.capacity)
 
-    fn __moveinit__(inout self, owned other: Self):
+    fn __moveinit__(mut self, owned other: Self):
         self.count = other.count
         self.capacity = other.capacity
         self.ocs = other.ocs^
         self.key_map = other.key_map
 
-    fn __copyinit__(inout self, other: Self):
+    fn __copyinit__(mut self, other: Self):
         self.count = other.count
         self.capacity = other.capacity
         # TODO: copies elements one by one because otherwise it throws a core dump
@@ -244,7 +244,7 @@ struct _CacheStringOrKey(Movable, Copyable):
     fn __del__(owned self):
         self.key_map.free()
 
-    fn put(inout self, oc: OffsetAndCount, pointer: DTypePointer[DType.uint8]):
+    fn put(mut self, oc: OffsetAndCount, pointer: DTypePointer[DType.uint8]):
         if self.count / self.capacity >= 0.8:
             self._rehash(pointer)
         self._put(oc, pointer, -1)
@@ -270,7 +270,7 @@ struct _CacheStringOrKey(Movable, Copyable):
                 return other_oc.offset
             key_map_index = (key_map_index + 1) & modulo_mask
 
-    fn _rehash(inout self, pointer: DTypePointer[DType.uint8]):
+    fn _rehash(mut self, pointer: DTypePointer[DType.uint8]):
         self.key_map.free()
         self.capacity <<= 1
         self.key_map = KeyMapPointer.alloc(self.capacity)
@@ -279,7 +279,7 @@ struct _CacheStringOrKey(Movable, Copyable):
             self._put(self.ocs[i], pointer, i + 1)
 
     fn _put(
-        inout self,
+        mut self,
         oc: OffsetAndCount,
         pointer: DTypePointer[DType.uint8],
         rehash_index: Int,

--- a/flexbuffers/flx_builder.mojo
+++ b/flexbuffers/flx_builder.mojo
@@ -9,16 +9,16 @@ struct FlxMap[
     var buffer: FlxBuffer[dedup_string, dedup_key, dedup_keys_vec]
 
     fn __init__(
-        inout self,
+        mut self,
         owned buffer: FlxBuffer[dedup_string, dedup_key, dedup_keys_vec],
     ):
         self.buffer = buffer^
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self.buffer = FlxBuffer[dedup_string, dedup_key, dedup_keys_vec]()
         self.buffer.start_map()
 
-    fn __moveinit__(inout self, owned other: Self):
+    fn __moveinit__(mut self, owned other: Self):
         self.buffer = other.buffer^
 
     fn add(owned self, key: String, value: Int) -> Self:
@@ -103,16 +103,16 @@ struct FlxVec[
     var buffer: FlxBuffer[dedup_string, dedup_key, dedup_keys_vec]
 
     fn __init__(
-        inout self,
+        mut self,
         owned buffer: FlxBuffer[dedup_string, dedup_key, dedup_keys_vec],
     ):
         self.buffer = buffer^
 
-    fn __init__(inout self):
+    fn __init__(mut self):
         self.buffer = FlxBuffer[dedup_string, dedup_key, dedup_keys_vec]()
         self.buffer.start_vector()
 
-    fn __moveinit__(inout self, owned other: Self):
+    fn __moveinit__(mut self, owned other: Self):
         self.buffer = other.buffer^
 
     fn add(owned self, value: Int) -> Self:

--- a/flexbuffers/flx_value.mojo
+++ b/flexbuffers/flx_value.mojo
@@ -12,7 +12,7 @@ struct FlxValue(Sized):
 
     @always_inline
     fn __init__(
-        inout self,
+        mut self,
         bytes: BufPointer,
         parent_byte_width: UInt8,
         packed_type: UInt8,
@@ -24,7 +24,7 @@ struct FlxValue(Sized):
 
     @always_inline
     fn __init__(
-        inout self,
+        mut self,
         bytes: BufPointer,
         parent_byte_width: UInt8,
         byte_width: UInt8,
@@ -35,7 +35,7 @@ struct FlxValue(Sized):
         self._byte_width = byte_width
         self._type = type
 
-    fn __init__(inout self, bytes: BufPointer, length: Int) raises:
+    fn __init__(mut self, bytes: BufPointer, length: Int) raises:
         if length < 3:
             raise "Length should be at least 3, was: " + String(length)
         var parent_byte_width = bytes[length - 1]
@@ -46,7 +46,7 @@ struct FlxValue(Sized):
         self._byte_width = 1 << (packed_type & 3)
         self._type = ValueType(packed_type >> 2)
 
-    fn __init__(inout self, bytes_and_length: (BufPointer, Int)) raises:
+    fn __init__(mut self, bytes_and_length: (BufPointer, Int)) raises:
         var bytes = bytes_and_length.get[0, BufPointer]()
         var length = bytes_and_length.get[1, Int]()
         if length < 3:
@@ -59,7 +59,7 @@ struct FlxValue(Sized):
         self._byte_width = 1 << (packed_type & 3)
         self._type = ValueType(packed_type >> 2)
 
-    fn __moveinit__(inout self, owned other: Self):
+    fn __moveinit__(mut self, owned other: Self):
         self._bytes = other._bytes
         self._parent_byte_width = other._parent_byte_width
         self._byte_width = other._byte_width
@@ -281,7 +281,7 @@ struct FlxVecValue(Sized):
 
     @always_inline
     fn __init__(
-        inout self,
+        mut self,
         bytes: BufPointer,
         byte_width: UInt8,
         type: ValueType,
@@ -337,7 +337,7 @@ struct FlxMapValue(Sized):
 
     @always_inline
     fn __init__(
-        inout self,
+        mut self,
         bytes: BufPointer,
         byte_width: UInt8,
         length: Int,

--- a/schema01_generated.mojo
+++ b/schema01_generated.mojo
@@ -19,7 +19,7 @@ struct Person:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: Optional[StringRef] = None,
         age: Int32 = 0,

--- a/schema02_generated.mojo
+++ b/schema02_generated.mojo
@@ -42,7 +42,7 @@ struct Date:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         day: UInt8,
         month: Month,
@@ -81,7 +81,7 @@ struct Person:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: Optional[StringRef] = None,
         birthday: Optional[DateVO] = None,

--- a/schema03_generated.mojo
+++ b/schema03_generated.mojo
@@ -42,7 +42,7 @@ struct Date:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         day: UInt8,
         month: Month,
@@ -84,7 +84,7 @@ struct PostalAddress:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         street: Optional[StringRef] = None,
         zip: Optional[StringRef] = None,
@@ -145,7 +145,7 @@ struct Person:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: Optional[StringRef] = None,
         birthday: Optional[DateVO] = None,

--- a/schema04_generated.mojo
+++ b/schema04_generated.mojo
@@ -41,7 +41,7 @@ struct Date:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         day: UInt8,
         month: Month,
@@ -81,7 +81,7 @@ struct PostalAddress:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         street: Optional[StringRef] = None,
         zip: Optional[StringRef] = None,
@@ -147,7 +147,7 @@ struct Person:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: Optional[StringRef] = None,
         birthday: Optional[DateVO] = None,

--- a/schema05_generated.mojo
+++ b/schema05_generated.mojo
@@ -41,7 +41,7 @@ struct Date:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         day: UInt8,
         month: Month,
@@ -81,7 +81,7 @@ struct PostalAddress:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         street: Optional[StringRef] = None,
         zip: Optional[StringRef] = None,
@@ -154,7 +154,7 @@ struct Person:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: Optional[StringRef] = None,
         birthday: Optional[DateVO] = None,

--- a/schema06_generated.mojo
+++ b/schema06_generated.mojo
@@ -41,7 +41,7 @@ struct Date:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         day: UInt8,
         month: Month,
@@ -81,7 +81,7 @@ struct PostalAddress:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         street: Optional[StringRef] = None,
         zip: Optional[StringRef] = None,
@@ -174,7 +174,7 @@ struct Person:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: Optional[StringRef] = None,
         birthday: Optional[DateVO] = None,

--- a/schema07_generated.mojo
+++ b/schema07_generated.mojo
@@ -56,7 +56,7 @@ struct Date:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         day: UInt8,
         month: Month,
@@ -108,7 +108,7 @@ struct PostalAddress:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         street: Optional[StringRef] = None,
         zip: Optional[StringRef] = None,
@@ -159,7 +159,7 @@ struct EmailAddress:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         email: Optional[StringRef] = None,
     ) -> flatbuffers.Offset:
@@ -277,7 +277,7 @@ struct Person:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: Optional[StringRef] = None,
         birthday: Optional[DateVO] = None,

--- a/schema08_generated.mojo
+++ b/schema08_generated.mojo
@@ -137,7 +137,7 @@ struct ScalarStuff:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         just_i8: Int8 = 0,
         maybe_i8: Optional[Int8] = None,

--- a/schema09_generated.mojo
+++ b/schema09_generated.mojo
@@ -24,7 +24,7 @@ struct T2:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         value: Int64 = 0,
         flags: List[Scalar[DType.bool]] = List[Scalar[DType.bool]](),
@@ -75,7 +75,7 @@ struct T1:
 
     @staticmethod
     fn build(
-        inout builder: flatbuffers.Builder,
+        mut builder: flatbuffers.Builder,
         *,
         name: StringRef,
         sibling: flatbuffers.Offset,


### PR DESCRIPTION
Replaces references to `inout` with `mut` as per the latest [changelog](https://docs.modular.com/mojo/changelog#v246-2024-12-17) from Mojo.

See the corresponding PR https://github.com/mzaks/flatbuffers/pull/1 for the implementation in the `flatc` codegen PR in the `flatbuffers` fork you have open.

Love the project, thank you!
